### PR TITLE
Decouple WebKit from WindowView

### DIFF
--- a/ios-web-browser/ios-web-browser.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios-web-browser/ios-web-browser.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "git@github.com:mauriciomaniglia/core-web-browser.git",
       "state" : {
         "branch" : "main",
-        "revision" : "d7b1d9079d4c2a2eeb593fdca693af0147c18884"
+        "revision" : "326b638ead39b978bd3e9b1583740c702139a0b2"
       }
     }
   ],

--- a/ios-web-browser/ios-web-browser/Window/Composition/WindowComposer.swift
+++ b/ios-web-browser/ios-web-browser/Window/Composition/WindowComposer.swift
@@ -3,11 +3,11 @@ import core_web_browser
 
 final class WindowComposer {
     static func makeScreen() -> UIViewController {
-        let windowView = WindowView()
         let windowViewController = UIViewController()
-        let webViewProxy = WebViewProxy(webView: windowView.webView)
+        let webViewProxy = WebViewProxy()
+        let windowView = WindowView(webView: webViewProxy.webView)
         let presenter = WindowPresenter()
-        let windowViewAdapter = WindowViewAdapter(webViewProxy: webViewProxy, presenter: presenter)
+        let windowViewAdapter = WindowViewAdapter(webView: webViewProxy, presenter: presenter)
 
         windowViewController.view = windowView
         windowView.delegate = windowViewAdapter

--- a/ios-web-browser/ios-web-browser/Window/Views/WindowView.swift
+++ b/ios-web-browser/ios-web-browser/Window/Views/WindowView.swift
@@ -1,18 +1,22 @@
 import UIKit
-import WebKit
 import core_web_browser
 
 public final class WindowView: UIView {
     public var delegate: WindowViewContract?
     public let searchBar = SearchBarView()
-    public let webView = WKWebView()
+    public let webView: UIView
     public let bottomNavigationView = NavigationBarView()
 
-    convenience init() {
-        self.init(frame: .zero)        
+    public init(webView: UIView) {
+        self.webView = webView
+        super.init(frame: .zero)
         setupView()
     }
-
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     public func updateViews(_ presentableModel: WindowPresentableModel) {
         bottomNavigationView.backButton.isEnabled = presentableModel.canGoBack
         bottomNavigationView.forwardButton.isEnabled = presentableModel.canGoForward

--- a/ios-web-browser/ios-web-browserTests/WindowViewTests.swift
+++ b/ios-web-browser/ios-web-browserTests/WindowViewTests.swift
@@ -4,10 +4,8 @@ import core_web_browser
 
 class WindowViewTests: XCTestCase {
     func test_textFieldShouldReturn_sendsText() {
-        let delegate = MainViewDelegateSpy()
-        let sut = WindowView()
-        sut.delegate = delegate
-                
+        let (sut, delegate) = makeSUT()
+
         let textField = UITextField()
         textField.text = "http://some-website.com"
         
@@ -17,10 +15,8 @@ class WindowViewTests: XCTestCase {
     }
 
     func test_textFieldShouldReturn_whenTextIsEmptyDoNotSendText() {
-        let delegate = MainViewDelegateSpy()
-        let sut = WindowView()
-        sut.delegate = delegate
-
+        let (sut, delegate) = makeSUT()
+        
         let textField = UITextField()
         textField.text = ""
 
@@ -30,7 +26,15 @@ class WindowViewTests: XCTestCase {
     }
     
     // MARK: - Helpers
-    
+
+    private func makeSUT() -> (sut: WindowView, delegate: MainViewDelegateSpy) {
+        let delegate = MainViewDelegateSpy()
+        let sut = WindowView(webView: UIView())
+        sut.delegate = delegate
+
+        return (sut, delegate)
+    }
+
     private class MainViewDelegateSpy: WindowViewContract {
         enum Message: Equatable {
             case didRequestSearch(_ text: String)


### PR DESCRIPTION
Issue: https://github.com/mauriciomaniglia/ios-web-browser/issues/1

- Remove WebKit reference from WindowView class since it's not needed.
- Organized unit tests. 